### PR TITLE
Update composer.json - Syntax error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "authors": [
         {"name": "Damien Pitard", "email": "d.pitard@creads.org"},
-        {"name": "Alexis Stefanski", "email": "a.stefanski@creads.org"},
+        {"name": "Alexis Stefanski", "email": "a.stefanski@creads.org"}
     ],
     "require": {
         "php": ">=5.4.0",


### PR DESCRIPTION
I push this to remove error when i use composer

```
Skipped branch feature/vendor-rename, "09a93bb4b9a8faca35c3007988a0eb785dcf0f6c:composer.json" does not contain valid JSON
Parse error on line 9:
...i@creads.org"},    ],    "require": {
---------------------^
Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[' - It appears you have an extra trailing comma
```